### PR TITLE
Add back gladGetProcAddressPtr declarations

### DIFF
--- a/glad/include/glad/glad.h
+++ b/glad/include/glad/glad.h
@@ -64,6 +64,8 @@ struct gladGLversionStruct {
 };
 
 typedef void* (* GLADloadproc)(const char *name);
+typedef void* (APIENTRYP PFNWGLGETPROCADDRESSPROC_PRIVATE)(const char*);
+static PFNWGLGETPROCADDRESSPROC_PRIVATE gladGetProcAddressPtr;
 
 #ifndef GLAPI
 # if defined(GLAD_GLAPI_EXPORT)

--- a/glad/src/glad.c
+++ b/glad/src/glad.c
@@ -29,9 +29,6 @@ static void* get_proc(const char *namez);
 #include <windows.h>
 static HMODULE libGL;
 
-typedef void* (APIENTRYP PFNWGLGETPROCADDRESSPROC_PRIVATE)(const char*);
-static PFNWGLGETPROCADDRESSPROC_PRIVATE gladGetProcAddressPtr;
-
 static
 int open_gl(void) {
     libGL = LoadLibraryW(L"opengl32.dll");


### PR DESCRIPTION
These declarations were removed from glad.h when glad was
regenerated in 8b75c25.

```
typedef void* (APIENTRYP PFNWGLGETPROCADDRESSPROC_PRIVATE)(const char*);
static PFNWGLGETPROCADDRESSPROC_PRIVATE gladGetProcAddressPtr;
```

This broke the build on Linux, as this is used in SOIL.c.

These changes also remove duplicate lines in the Windows ifdefs in
glad.c, as they are already present in the header.